### PR TITLE
feat(add): techdocs workflows and remove aws-fullstack-app template title duplication

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+## Pull Request Checklist
+
+Please ensure you have completed the following checks before submitting your pull request:
+
+### Description
+
+Briefly explain the purpose of your pull request.
+
+### Content Checks
+
+- [ ] Have you included a `catalog-info.yaml` file for your content?
+  - [ ] Is the `catalog-info.yaml` file complete and accurate?
+
+### Template Checks
+
+- [ ] Have you included a `template.yaml` file for your scaffolder template?
+  - [ ] Is the `template.yaml` file complete and accurate?
+
+### Documentations
+
+- [ ] Have you updated the relevant documentation? If so, have you follow the folder structures for both TechDocs and ADRs?
+  - [ ] Are there TechDocs (`docs/ techdocs/<app_name>`) for the new/updated component?
+  - [ ] Have you added Architectural Decision Records (ADRs) if applicable in `docs/decisions/<app_name>`?
+
+### Additional Notes
+
+Please add any additional notes or comments here that you think are relevant to your pull request.

--- a/.github/workflows/techdocs.yaml
+++ b/.github/workflows/techdocs.yaml
@@ -1,0 +1,63 @@
+name: Publish Product Central TechDocs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "architectures/docs/techdocs/**"
+  # Run Daily at 10:00 UTC time
+  schedule:
+    - cron: "0 10 * * *"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish-product-central-techdocs:
+    name: Publish Product Central TechDocs
+    runs-on: ubuntu-latest
+
+    env:
+      TECHDOCS_S3_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_REGION: ${{ secrets.AWS_REGION }}
+      ENTITY_NAMESPACE: "default"
+      ENTITY_KIND: "Component"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Setup local Turbo cache
+        uses: dtinth/setup-github-actions-caching-for-turbo@v1
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+
+      - name: Install techdocs-cli
+        run: sudo npm install -g @techdocs/cli
+
+      - name: Install mkdocs and mkdocs plugins
+        run: python -m pip install mkdocs-techdocs-core==1.*
+
+      - name: Generate and Publish docs site
+        run: |
+          for dir in docs/techdocs/*/ ; do
+            ENTITY_NAME=$(basename "$dir")
+            echo "Generating docs for $ENTITY_NAME"
+            cd "$dir"
+            techdocs-cli generate --no-docker --output-dir "site" --verbose
+            cd -  # Return to the previous directory
+            echo "Publishing docs for $ENTITY_NAME"
+            techdocs-cli publish --publisher-type awsS3 --storage-name $TECHDOCS_S3_BUCKET_NAME --entity $ENTITY_NAMESPACE/$ENTITY_KIND/$ENTITY_NAME --directory "$dir/site"
+          done

--- a/architectures/github/aws-fullstack-app/template.yaml
+++ b/architectures/github/aws-fullstack-app/template.yaml
@@ -33,8 +33,6 @@ spec:
         - name
         - repoUrl
         - description
-        - coreAppName
-        - remoteAppName
       properties:
         name:
           title: Name


### PR DESCRIPTION
1. Added techdocs manifests to publish techdocs to AWS when `architecture/docs/techdocs/**` files changes
2. Fixed `aws-fullstack-app` template parameter title duplication