### PR TITLE
fix(auth): github auth callback url

### DIFF
--- a/docs/home/quick-start.md
+++ b/docs/home/quick-start.md
@@ -74,5 +74,5 @@ docker run -it -p 7007:7007 \
         * Application name: The name of your application.
         * Homepage URL: The URL of your application. For instance, `http://localhost:3000`.
         * Application description: A brief description of your application.
-        * Authorization callback URL: The URL to redirect to after the user authorizes the app. For instance, `http://localhost:3000/api/auth/callback/github`.
+        * Authorization callback URL: The URL to redirect to after the user authorizes the app. For instance, `http://localhost:3000/api/auth/github/handler/frame`.
     * Once created, find the client ID and `generate new` client secret from the app settings.


### PR DESCRIPTION
## Pull Request Checklist

Please ensure you have completed the following checks before submitting your pull request:

### Description

Updated Github OAuth Callback url with reference to the official documentation of [Backstage](https://backstage.io/docs/auth/github/provider/#create-an-oauth-app-on-github)

### Content Checks

- [ ] Have you included a `catalog-info.yaml` file for your content?
  - [ ] Is the `catalog-info.yaml` file complete and accurate?

### Template Checks

- [ ] Have you included a `template.yaml` file for your scaffolder template?
  - [ ] Is the `template.yaml` file complete and accurate?

### Documentations

- [ ] Have you updated the relevant documentation? If so, have you follow the folder structures for both TechDocs and ADRs?
  - [ ] Are there TechDocs (`docs/ techdocs/<app_name>`) for the new/updated component?
  - [ ] Have you added Architectural Decision Records (ADRs) if applicable in `docs/decisions/<app_name>`?

### Additional Notes

Fixes the issue "The `redirect_url` is not associated with this application"